### PR TITLE
Fooling the compiler

### DIFF
--- a/fooling the compiler
+++ b/fooling the compiler
@@ -1,0 +1,22 @@
+#include<iostream.h>
+#include<conio.h>
+class test
+{int a;
+public:
+void read()
+{a=10;
+}                              // private member value is changing. without using any friend function or any member functio of class.
+void display()
+{cout<<a<<endl;
+}
+};
+void main()
+{clrscr();
+test t;
+t.read();
+t.display();
+int *ptr=(int*)&t;
+*ptr=99;
+t.display();
+getch();
+}


### PR DESCRIPTION
this code can change the private value of class(data members) without friend function or member function. I discovered this while i was getting an error regarding ponters. So i worked on that error and made a code that is totally opposite of the principle of data hiding.